### PR TITLE
update ATS plugin to 4.x and 5.x API, update docs accordingly

### DIFF
--- a/docs/webserverplugins.rst
+++ b/docs/webserverplugins.rst
@@ -44,23 +44,69 @@ You'll need to customize this::
         }
 
 
-Apache Traffic Server Plugin
-----------------------------
-
+Apache Traffic Server (ATS) Plugin
+----------------------------------
 
 Requirements
 ~~~~~~~~~~~~
 
-- lua 5.1 and dev packages
-- ats compiled with --enable-experimental-plugins
-- requires using sha256 auth_tkt hash algorithm
+- ATS 5.3.x (tested on 5.3, but it _should_ work on other 5.x and 4.x releases)
+  configured as a reverse proxy server
+- ATS Lua plugin
+
+See the `Apache Traffic Server Documentation <https://docs.trafficserver.apache.org/en/latest/index.html>`_
+for how to install and configure it. Take note that you will need to use a version of
+ATS compiled with the `--enable-experimental-plugins`, or you will need to configure
+your installation to work with the `TS-Lua <https://github.com/portl4t/ts-lua>`_ plugin.
 
 
 Install
 ~~~~~~~
 
-- copy ats plugin directory to where you want to configure it
-- configure plugin directory/factored.lua settings to match factored settings
-- Finally, in your remap config, use something like::
+Put the following into a file that is readable by ATS (ex:
+``/etc/factored/plugin.lua``):::
 
-    map http://www.foobar.com/ http://127.0.0.1:8080/ @plugin=lua.so @pparam=/path/to/ats/plugin/factored.lua
+    --
+    --  These should match your factored settings (IE the values in your INI
+    --  configuration file). This value SHOULD be called "factored_settings".
+    --
+    factored_settings = {
+      -- the HOST and PORT Factored is running on
+      host='127.0.0.1',
+      port=8000,
+
+      -- AUTH TKT settings
+      cookie_name='pnutbtr',
+      secret='secret',
+      include_ip=false, -- [true] to include IP in cookie value
+      timeout=false, -- [true] to manually handle cookie timeouts
+
+      -- PLUGIN directory -- by default factored has a "plugins" directory
+      -- which contains several lua files that are necessary. This directory
+      -- should contain "ats.lua", "factored.lua", "bit.lua", and "sha.lua"
+      basepath='/opt/factored/src/plugins/'
+    }
+
+    -- this needs to be in your custom settings file, and probably doesn't
+    -- need to be modified.
+    require 'package'
+    if string.find(package.path, factored_settings.basepath) == nil then
+        ts.add_package_path(factored_settings.basepath .. '?.lua')
+    end
+    require 'ats'
+
+Then in your ATS ``remap.config`` file, you'll want a line like the
+following:::
+
+    map TARGET REPLACEMENT @plugin=/path/to/tslua.so @pparam=/path/to/your/custom/settings.lua
+
+Where 'TARGET' would be the incoming URL and 'REPLACEMENT' is the upstream
+(NOT the factored server, but whichever URL you want behind factored).
+
+The ``/path/to/tslua.so`` is going to be based on your installation -- a
+default ATS installation from source on Ubuntu will put it in
+``/usr/local/libexec/tslua.so``.
+
+The ``/path/to/your/custom/settings.lua`` would be the path to the file
+that contains your customized factored configuration
+(``/etc/factored/plugin.lua`` from the example above).

--- a/plugins/ats.lua
+++ b/plugins/ats.lua
@@ -1,50 +1,92 @@
 --[[
 --  These settings should match with your factored settings.
---]]
-local settings = {
-  -- this is factored host it's running on
+--
+--  Put these in a file on a path that ATS can read from, then modify the
+--  ATS remap config to have a line similar to:
+--
+--      map X Y @plugin=/path/to/tslua.so @pparam=/path/to/your/custom/settings.lua
+--
+--  See the documentation for more detailed info.
+--
+--  Below is an example config file:
+
+--
+--  These should match your factored settings (IE the values in your INI
+--  configuration file). This value SHOULD be called "factored_settings".
+--
+factored_settings = {
+  -- the HOST and PORT Factored is running on
   host='127.0.0.1',
-  -- factored port it's running
   port=8000,
-  -- do we also need to provide way to override factored auth path?
-  -- auth tkt cookie name
+
+  -- AUTH TKT settings
   cookie_name='pnutbtr',
-  -- auth tkt secret
   secret='secret',
-  -- include ip for cookie value
-  include_ip=false,
-  -- manually handle cookie timeouts
-  timeout=false,
-  -- base path to the plugin source files
-  basepath='/home/nathan/code/factored/ats/'
--- hashalg = md5
+  include_ip=false, -- [true] to include IP in cookie value
+  timeout=false, -- [true] to manually handle cookie timeouts
+
+  -- PLUGIN directory -- by default factored has a "plugins" directory
+  -- which contains several lua files that are necessary. This directory
+  -- should contain "ats.lua", "factored.lua", "bit.lua", and "sha.lua"
+  basepath='/opt/factored/src/plugins/'
 }
 
-local ts = require 'ts'
+-- this needs to be in your custom settings file, and probably doesn't
+-- need to be modified.
+require 'package'
+if string.find(package.path, factored_settings.basepath) == nil then
+    ts.add_package_path(factored_settings.basepath .. '?.lua')
+end
+require 'ats'
+
+--]]
+
 
 require 'string'
 require 'math'
 require 'package'
 require 'os'
 
--- add plugin directory to load path
-require 'debug'
-local basepath = debug.getinfo(1).source
-basepath = basepath:sub(2, string.len(basepath) - 7)  -- pull out actual path
-package.path = package.path .. ';' .. basepath .. '?.lua'
-
+if string.find(package.path, factored_settings.basepath) == nil then
+    ts.add_package_path(factored_settings.basepath .. '?.lua')
+end
 require 'factored'
 
--- Compulsory remap hook. We are given a request object that we can modify if necessary.
-function remap(request)
-  -- Get a copy of the current URL.
-  url = request:url()
-  local cookies = parse_cookies(request.headers.Cookie)
-  local cookie = cookies[settings.cookie_name]
+
+-- these are used to "cache" client request values so they can be used to
+-- communicate correctly with factored through HTTP headers
+local pristine_scheme = ''
+local pristine_host = ''
+local pristine_port = ''
+
+
+--
+-- modify the request sent to the upstream server to reset the headers used
+-- by Factored to generate proper URL's for it's internal use
+--
+function send_request()
+    ts.server_request.header['X-Forwarded-Protocol'] = pristine_scheme
+    final_host = pristine_host
+    -- only add the port if it's non-standard. It would make ugly url's,
+    -- and likely urls that are not expected otherwise
+    if pristine_port ~= '80' and pristine_port ~= '443' then
+        final_host = final_host .. ':' .. pristine_port
+    end
+    ts.server_request.header['Host'] = final_host
+end
+
+--
+-- verify the AUTH TKT cookie is valid, and then either interdict the
+-- request, forwarding it to factored, or allow the request to pass
+-- directly to the origin
+--
+function _do_remap()
+  local cookies = parse_cookies(ts.client_request.header.Cookie)
+  local cookie = cookies[factored_settings.cookie_name]
 
   local remote_addr = '0.0.0.0'
-  if settings.include_ip then
-    ip, port, family = request.client_addr.get_addr()
+  if factored_settings.include_ip then
+    ip, port, family = ts.client_request.client_addr.get_addr()
     remote_addr = ip
   end
 
@@ -54,7 +96,7 @@ function remap(request)
     if cookie == nil then
       return false
     end
-    return valid_auth_tkt(settings, cookie.value, remote_addr)
+    return valid_auth_tkt(factored_settings, cookie.value, remote_addr)
   end)
 
   if ok then
@@ -67,16 +109,45 @@ function remap(request)
     print('Error checking cookie: ' .. err)
   end
 
+  -- this is where the request is interdicted, if the user is not
+  -- determined to be authorized
   if rewrite then
-    url.host = settings.host
-    url.port = settings.port
-    -- Rewrite the request URL. The remap plugin chain continues and other plugins
-    request:rewrite(url)
+    -- store clean values from the client url and then setup
+    -- a hook to alter the headers sent to the upstream server
+    pristine_host = ts.client_request.get_url_host()
+    pristine_port = ts.client_request.get_url_port()
+    pristine_scheme = ts.client_request.get_url_scheme()
+    ts.hook(TS_LUA_HOOK_SEND_REQUEST_HDR, send_request)
+
+    -- remap the upstream to point at the factored instance
+    ts.client_request.set_url_host(factored_settings.host)
+    ts.client_request.set_url_port(factored_settings.port)
+    return TS_LUA_REMAP_DID_REMAP
   end
 
+  return TS_LUA_REMAP_NO_REMAP
 end
 
--- Optional module initialization hook.
-function init()
-  return true
+-- XXX: could make this configurable in the factored_settings maybe,
+-- but it is a special case, only if there was an error with
+-- the guts of the plugin
+function factored_failed()
+  local resp = 'HTTP/1.1 403 Forbidden\r\n' ..
+               'Content-Type: text/plain\r\n\r\n' ..
+               'Access Denied\n'
+  ts.say(resp)
+end
+
+--
+-- attempt to interdict the request, if necessary if there was an unhandled
+-- error of some sort, prevent access to the upstream.
+--
+function do_remap()
+  local status, ret = pcall(_do_remap)
+  if status then
+    return ret
+  else
+    ts.http.intercept(factored_failed) 
+    return 0
+  end
 end


### PR DESCRIPTION
Tested on 5.3.x, but should work for any 5.x or 4.x ATS installation.

This update adds documentation for a suggested configuration, and updates the ATS specific portion of the LUA plugins to be compatible with the latest ATS ts-lua plugin API.